### PR TITLE
Fix ntp service check for ubuntu

### DIFF
--- a/pre-install/cluster-audit.sh
+++ b/pre-install/cluster-audit.sh
@@ -245,7 +245,7 @@ clush ${parg/-b /} 'host $(hostname -i)'; echo $sep
 case ${EFFECTIVE_DISTRO} in
    ubuntu)
       # Ubuntu SElinux tools not so good.
-      clush $parg "echo 'NTP status '; ${SUDO:-} service ntpd status"; echo $sep
+      clush $parg "echo 'NTP status '; ${SUDO:-} service ntp status"; echo $sep
       clush $parg "${SUDO:-} apparmor_status | sed 's/([0-9]*)//'"; echo $sep
       clush $parg "echo -n 'SElinux status: '; ([ -d /etc/selinux -a -f /etc/selinux/config ] && grep ^SELINUX= /etc/selinux/config) || echo Disabled"
       echo $sep


### PR DESCRIPTION
ubuntu 16.04 and 18.04 run `ntpd` service as `ntp`

```
# systemctl status ntp
● ntp.service - Network Time Service
   Loaded: loaded (/lib/systemd/system/ntp.service; enabled; vendor preset: enabled)
   Active: active (running) since Wed 2022-02-23 19:06:48 UTC; 1h 0min ago
     Docs: man:ntpd(8)
 Main PID: 11837 (ntpd)
    Tasks: 2 (limit: 1134)
   CGroup: /system.slice/ntp.service
           └─11837 /usr/sbin/ntpd -p /var/run/ntpd.pid -g -u 111:115

Feb 23 20:04:49 ip-10-0-1-146 ntpd[11837]: Soliciting pool server 2001:418:3ff::1:53
Feb 23 20:04:52 ip-10-0-1-146 ntpd[11837]: Soliciting pool server 50.240.14.74
Feb 23 20:05:44 ip-10-0-1-146 ntpd[11837]: Soliciting pool server 91.189.91.157
Feb 23 20:05:45 ip-10-0-1-146 ntpd[11837]: Soliciting pool server 209.51.161.238
Feb 23 20:05:48 ip-10-0-1-146 ntpd[11837]: Soliciting pool server 217.180.209.214
Feb 23 20:05:56 ip-10-0-1-146 ntpd[11837]: Soliciting pool server 2001:19f0:200:144b::2000
Feb 23 20:05:58 ip-10-0-1-146 ntpd[11837]: Soliciting pool server 72.30.35.89
Feb 23 20:06:48 ip-10-0-1-146 ntpd[11837]: Soliciting pool server 91.189.94.4
Feb 23 20:06:51 ip-10-0-1-146 ntpd[11837]: Soliciting pool server 108.61.56.35
Feb 23 20:06:54 ip-10-0-1-146 ntpd[11837]: Soliciting pool server 38.100.216.142
```